### PR TITLE
Take &str data argument in `send()`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,13 +32,13 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: check
-        args: --all --bins --examples --features hyperium_http
+        args: --all --bins --examples
 
     - name: check unstable
       uses: actions-rs/cargo@v1
       with:
         command:  check
-        args: --all --benches --bins --examples --tests --features hyperium_http
+        args: --all --benches --bins --examples --tests
 
     - name: tests
       uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,3 @@ pin-project-lite = "0.1.4"
 [dev-dependencies]
 femme = "1.3.0"
 async-std = { version = "1.5.0", features = ["attributes", "unstable"] }
-
-[patch.crates-io]
-async-std = { path = "../async-std" }

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -95,7 +95,7 @@ pub fn encode() -> (Sender, Encoder) {
 
 impl Sender {
     /// Send a new message over SSE.
-    pub async fn send(&self, name: &str, data: &[u8], id: Option<&str>) {
+    pub async fn send(&self, name: &str, data: &str, id: Option<&str>) {
         // Write the event name
         let msg = format!("event:{}\n", name);
         self.0.send(msg.into_bytes()).await;
@@ -106,10 +106,8 @@ impl Sender {
         }
 
         // Write the data section, and end.
-        let mut msg = b"data:".to_vec();
-        msg.extend_from_slice(data);
-        msg.extend_from_slice(b"\n\n");
-        self.0.send(msg).await;
+        let msg = format!("data:{}\n\n", data);
+        self.0.send(msg.into_bytes()).await;
     }
 
     /// Send a new "retry" message over SSE.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //!     // Create an encoder + sender pair and send a message.
 //!     let (sender, encoder) = encode();
 //!     task::spawn(async move {
-//!         sender.send("cat", b"chashu", None).await;
+//!         sender.send("cat", "chashu", None).await;
 //!     });
 //!
 //!     // Decode messages using a decoder.

--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -30,7 +30,7 @@ fn assert_retry(event: &Event, dur: u64) {
 async fn encode_message() -> http_types::Result<()> {
     let (sender, encoder) = encode();
     task::spawn(async move {
-        sender.send("cat", b"chashu", None).await;
+        sender.send("cat", "chashu", None).await;
     });
 
     let mut reader = decode(BufReader::new(encoder));
@@ -43,7 +43,7 @@ async fn encode_message() -> http_types::Result<()> {
 async fn encode_message_with_id() -> http_types::Result<()> {
     let (sender, encoder) = encode();
     task::spawn(async move {
-        sender.send("cat", b"chashu", Some("0")).await;
+        sender.send("cat", "chashu", Some("0")).await;
     });
 
     let mut reader = decode(BufReader::new(encoder));


### PR DESCRIPTION
EventSource streams are [required to be utf-8](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation), and we can encode that requirement in the type system by using `&str` for the `data` argument :)