### PR TITLE
Notify the Sender that the Encoder has been dropped

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ async-std = { version = "1.6.0", features = ["unstable"] }
 http-types = "2.0.1"
 log = "0.4.8"
 memchr = "2.3.3"
-pin-project-lite = "0.1.4"
+pin-project = "0.4.22"
 
 [dev-dependencies]
 femme = "2.0.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ mod lines;
 mod message;
 
 pub use decoder::{decode, Decoder};
-pub use encoder::{encode, Encoder, Sender};
+pub use encoder::{encode, DisconnectedError, Encoder, Sender};
 pub use event::Event;
 pub use handshake::upgrade;
 pub use message::Message;

--- a/src/lines.rs
+++ b/src/lines.rs
@@ -2,30 +2,29 @@ use std::mem;
 use std::pin::Pin;
 use std::str;
 
-use pin_project_lite::pin_project;
+use pin_project::pin_project;
 
 use async_std::io::{self, BufRead};
 use async_std::stream::Stream;
 use async_std::task::{ready, Context, Poll};
 
-pin_project! {
-    /// A stream of lines in a byte stream.
-    ///
-    /// This stream is created by the [`lines`] method on types that implement [`BufRead`].
-    ///
-    /// This type is an async version of [`std::io::Lines`].
-    ///
-    /// [`lines`]: trait.BufRead.html#method.lines
-    /// [`BufRead`]: trait.BufRead.html
-    /// [`std::io::Lines`]: https://doc.rust-lang.org/std/io/struct.Lines.html
-    #[derive(Debug)]
-    pub(crate) struct Lines<R> {
-        #[pin]
-        pub(crate) reader: R,
-        pub(crate) buf: String,
-        pub(crate) bytes: Vec<u8>,
-        pub(crate) read: usize,
-    }
+/// A stream of lines in a byte stream.
+///
+/// This stream is created by the [`lines`] method on types that implement [`BufRead`].
+///
+/// This type is an async version of [`std::io::Lines`].
+///
+/// [`lines`]: trait.BufRead.html#method.lines
+/// [`BufRead`]: trait.BufRead.html
+/// [`std::io::Lines`]: https://doc.rust-lang.org/std/io/struct.Lines.html
+#[pin_project]
+#[derive(Debug)]
+pub(crate) struct Lines<R> {
+    #[pin]
+    pub(crate) reader: R,
+    pub(crate) buf: String,
+    pub(crate) bytes: Vec<u8>,
+    pub(crate) read: usize,
 }
 
 impl<R> Lines<R> {


### PR DESCRIPTION
This changes the signature of Sender::send to return a Result that indicates whether the send was successful, allowing tide or other consumers to use `?` to break out of a send loop.

This PR replaces pin-project-lite with pin-project in order to use pinned drop. A shared `Arc<AtomicBool>` is the concurrency primitive, which seemed like the simplest thing that could possibly work.

This addresses http-rs/tide#591 in conjunction with http-rs/tide#598