### PR TITLE
Sender::send(name: Into<Option<&str>>, ..)

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -101,8 +101,8 @@ impl Sender {
     }
 
     /// Send a new message over SSE.
-    pub async fn send<'a, N>(&self, name: N, data: &str, id: Option<&str>) -> io::Result<()> 
-    where 
+    pub async fn send<'a, N>(&self, name: N, data: &str, id: Option<&str>) -> io::Result<()>
+    where
         N: Into<Option<&'a str>>,
     {
         // Write the event name
@@ -110,7 +110,7 @@ impl Sender {
             let msg = format!("event:{}\n", name);
             self.inner_send(msg).await?;
         }
-        
+
         // Write the id
         if let Some(id) = id {
             self.inner_send(format!("id:{}\n", id)).await?;

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -101,11 +101,16 @@ impl Sender {
     }
 
     /// Send a new message over SSE.
-    pub async fn send(&self, name: &str, data: &str, id: Option<&str>) -> io::Result<()> {
+    pub async fn send<'a, N>(&self, name: N, data: &str, id: Option<&str>) -> io::Result<()> 
+    where 
+        N: Into<Option<&'a str>>,
+    {
         // Write the event name
-        let msg = format!("event:{}\n", name);
-        self.inner_send(msg).await?;
-
+        if let Some(name) = name.into() {
+            let msg = format!("event:{}\n", name);
+            self.inner_send(msg).await?;
+        }
+        
         // Write the id
         if let Some(id) = id {
             self.inner_send(format!("id:{}\n", id)).await?;


### PR DESCRIPTION
Messages may not need to provide the `event` field. https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events-intro
