### PR TITLE
Support sending events without an `event:` field for the event name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-sse"
-version = "4.1.0"
+version = "5.0.0"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/http-rs/async-sse"
 documentation = "https://docs.rs/async-sse"

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -100,10 +100,16 @@ impl Sender {
     }
 
     /// Send a new message over SSE.
-    pub async fn send(&self, name: &str, data: &str, id: Option<&str>) -> io::Result<()> {
+    pub async fn send(
+        &self,
+        name: impl Into<Option<&str>>,
+        data: &str,
+        id: Option<&str>,
+    ) -> io::Result<()> {
         // Write the event name
-        let msg = format!("event:{}\n", name);
-        self.inner_send(msg).await?;
+        if let Some(name) = name.into() {
+            self.inner_send(format!("event:{}\n", name)).await?;
+        }
 
         // Write the id
         if let Some(id) = id {

--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -38,6 +38,28 @@ async fn encode_message() -> http_types::Result<()> {
 }
 
 #[async_std::test]
+async fn encode_message_some() -> http_types::Result<()> {
+    let (sender, encoder) = encode();
+    task::spawn(async move { sender.send(Some("cat"), "chashu", None).await });
+
+    let mut reader = decode(BufReader::new(encoder));
+    let event = reader.next().await.unwrap()?;
+    assert_message(&event, "cat", "chashu", None);
+    Ok(())
+}
+
+#[async_std::test]
+async fn encode_message_data_only() -> http_types::Result<()> {
+    let (sender, encoder) = encode();
+    task::spawn(async move { sender.send(None, "chashu", None).await });
+
+    let mut reader = decode(BufReader::new(encoder));
+    let event = reader.next().await.unwrap()?;
+    assert_message(&event, "message", "chashu", None);
+    Ok(())
+}
+
+#[async_std::test]
 async fn encode_message_with_id() -> http_types::Result<()> {
     let (sender, encoder) = encode();
     task::spawn(async move { sender.send("cat", "chashu", Some("0")).await });
@@ -45,6 +67,17 @@ async fn encode_message_with_id() -> http_types::Result<()> {
     let mut reader = decode(BufReader::new(encoder));
     let event = reader.next().await.unwrap()?;
     assert_message(&event, "cat", "chashu", Some("0"));
+    Ok(())
+}
+
+#[async_std::test]
+async fn encode_message_data_only_with_id() -> http_types::Result<()> {
+    let (sender, encoder) = encode();
+    task::spawn(async move { sender.send(None, "chashu", Some("0")).await });
+
+    let mut reader = decode(BufReader::new(encoder));
+    let event = reader.next().await.unwrap()?;
+    assert_message(&event, "message", "chashu", Some("0"));
     Ok(())
 }
 


### PR DESCRIPTION
The event field is optional in the specification, and adds overhead,
which some applications do not want. Allow omitting it.

To simplify use, accept the name as `impl Into<Option<&str>>`, which
allows existing code that passes `"name"` to continue working. Since
this can potentially cause an inference failure in code that previously
compiled, bump the major version, but *most* code should continue
working with just a recompile.