### PR TITLE
deps: replace async-std with futures-lite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ authors = [
 [features]
 
 [dependencies]
-async-std = { version = "1.6.0", features = ["unstable"] }
-http-types = "2.0.1"
+futures-lite = "1.11.3"
+http-types = { version = "2.0.1", default-features = false }
 log = "0.4.8"
 memchr = "2.3.3"
 pin-project-lite = "0.1.4"

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,11 +1,11 @@
-use async_std::io::BufRead as AsyncBufRead;
-use async_std::stream::Stream;
-use async_std::task::{self, Context, Poll};
+use crate::Lines;
+use futures_lite::prelude::*;
+use futures_lite::ready;
+use std::task::{Context, Poll};
 
 use std::pin::Pin;
 
 use crate::Event;
-use crate::Lines;
 
 /// Decode a new incoming SSE connection.
 pub fn decode<R>(reader: R) -> Decoder<R>
@@ -69,7 +69,7 @@ impl<R: AsyncBufRead + Unpin> Stream for Decoder<R> {
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         loop {
             // Get the next line, if available.
-            let line = match task::ready!(Pin::new(&mut self.lines).poll_next(cx)) {
+            let line = match ready!(Pin::new(&mut self.lines).poll_next(cx)) {
                 None => return Poll::Ready(None),
                 Some(Err(e)) => return Poll::Ready(Some(Err(e.into()))),
                 Some(Ok(line)) => line,

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -1,6 +1,6 @@
-use async_std::io::{BufRead as AsyncBufRead, Read as AsyncRead};
-use async_std::prelude::*;
-use async_std::task::{ready, Context, Poll};
+use futures_lite::prelude::*;
+use futures_lite::ready;
+use std::task::{Context, Poll};
 
 use std::io;
 use std::pin::Pin;


### PR DESCRIPTION
It may be useful to be able to use this in more ecosystems without
taking the whole async-std dependency. The async-std dependency was
mostly through re-exports that can instead be taken directly on the
futures crate.