### PR TITLE
add support for multiline data messages

### DIFF
--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -117,8 +117,11 @@ impl Sender {
         }
 
         // Write the data section, and end.
-        let msg = format!("data:{}\n\n", data);
-        self.inner_send(msg).await?;
+        for line in data.lines() {
+            let msg = format!("data:{}\n", line);
+            self.inner_send(msg).await?;
+        }
+        self.inner_send("\n").await?;
 
         Ok(())
     }

--- a/tests/encode.rs
+++ b/tests/encode.rs
@@ -96,6 +96,17 @@ async fn encode_retry() -> http_types::Result<()> {
 }
 
 #[async_std::test]
+async fn encode_multiline_message() -> http_types::Result<()> {
+    let (sender, encoder) = encode();
+    task::spawn(async move { sender.send("cats", "chashu\nnori", None).await });
+
+    let mut reader = decode(BufReader::new(encoder));
+    let event = reader.next().await.unwrap()?;
+    assert_message(&event, "cats", "chashu\nnori", None);
+    Ok(())
+}
+
+#[async_std::test]
 async fn dropping_encoder() -> http_types::Result<()> {
     let (sender, encoder) = encode();
     let sender_clone = sender.clone();


### PR DESCRIPTION
Currently, the `data` passed to `Sender::send()` is prepended with `data:` and written as-is. If the data string contains newlines, that causes any data beyond the newline(s) to end up on a line that does *not* begin with `data:`, which [the spec dictates](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation) should be ignored (or, worse, if the message itself contains a field name, like `event:` or `id:`, after a newline, it could register on the client side as a separate event). This change splits the message on newlines and writes each line with its own `data:` prefix.

The decoder code seems to handle this case correctly already.